### PR TITLE
Do not index string as it gets saved as bytes and cannot decode when …

### DIFF
--- a/interfaces/INameWrapper.sol
+++ b/interfaces/INameWrapper.sol
@@ -15,7 +15,7 @@ uint96 constant CAN_DO_EVERYTHING = 0;
 interface INameWrapper is IERC1155 {
     event NameWrapped(
         bytes32 indexed parentNode,
-        string indexed label,
+        string label,
         address owner,
         uint96 fuses
     );


### PR DESCRIPTION
Indexing string will emit events on bytes hence cannot decode when indexing on subgraph

Reference: https://github.com/ChainSafe/web3.js/issues/550